### PR TITLE
Add metadata fields to cinematography shots

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Cinematography Shots Website
 
-A simple Flask application for storing and displaying cinematography shots. Upload images with optional titles and browse your gallery.
+A simple Flask application for storing and displaying cinematography shots. Upload images with metadata including title, movie, director, director of photography, and release year. Browse your gallery with all details shown.
 
 ### Running locally
 

--- a/cine_storage/app.py
+++ b/cine_storage/app.py
@@ -43,12 +43,23 @@ def index():
 def upload():
     file = request.files.get('shot')
     title = request.form.get('title', '')
+    movie = request.form.get('movie', '')
+    director = request.form.get('director', '')
+    dop = request.form.get('dop', '')
+    year = request.form.get('year', '')
     if file and allowed_file(file.filename):
         filename = datetime.now().strftime('%Y%m%d%H%M%S_') + secure_filename(file.filename)
         filepath = os.path.join(app.config['UPLOAD_FOLDER'], filename)
         file.save(filepath)
         entries = load_entries()
-        entries.insert(0, {'title': title, 'filename': filename})
+        entries.insert(0, {
+            'title': title,
+            'filename': filename,
+            'movie': movie,
+            'director': director,
+            'dop': dop,
+            'year': year,
+        })
         save_entries(entries)
     return redirect(url_for('index'))
 

--- a/cine_storage/templates/index.html
+++ b/cine_storage/templates/index.html
@@ -76,7 +76,11 @@
       <h1>Cinematography Shots</h1>
     </header>
     <form action="{{ url_for('upload') }}" method="post" enctype="multipart/form-data">
-      <input type="text" name="title" placeholder="Title" />
+      <input type="text" name="title" placeholder="Shot title" />
+      <input type="text" name="movie" placeholder="Movie" />
+      <input type="text" name="director" placeholder="Director" />
+      <input type="text" name="dop" placeholder="Director of Photography" />
+      <input type="number" name="year" placeholder="Year" min="1888" />
       <input type="file" name="shot" required />
       <input type="submit" value="Upload" />
     </form>
@@ -86,6 +90,12 @@
       <li>
         {% if entry.title %}<h3>{{ entry.title }}</h3>{% endif %}
         <img src="{{ url_for('uploaded_file', filename=entry.filename) }}" alt="{{ entry.title }}" />
+        <p>
+          {% if entry.movie %}<strong>Movie:</strong> {{ entry.movie }}<br>{% endif %}
+          {% if entry.director %}<strong>Director:</strong> {{ entry.director }}<br>{% endif %}
+          {% if entry.dop %}<strong>DOP:</strong> {{ entry.dop }}<br>{% endif %}
+          {% if entry.year %}<strong>Year:</strong> {{ entry.year }}{% endif %}
+        </p>
       </li>
     {% else %}
       <li>No shots yet.</li>


### PR DESCRIPTION
## Summary
- allow uploading additional metadata: movie, director, DOP and year
- show the metadata in the gallery
- describe metadata in README

## Testing
- `python -m py_compile cine_storage/app.py`
- `pip install -r requirements.txt`
- `python cine_storage/app.py` *(runs for a short time)*

------
https://chatgpt.com/codex/tasks/task_e_6840af853f688331b1bb400ee0e54efc