### PR TITLE
Add dedicated upload page

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A simple Flask application for storing and displaying cinematography shots. Upload images with metadata including title, movie, director, director of photography, and release year. Browse your gallery with all details shown.
 
+Visit `/` to view the gallery. Use `/upload` to add new shots with their metadata.
+
 ### Running locally
 
 ```bash

--- a/cine_storage/app.py
+++ b/cine_storage/app.py
@@ -38,9 +38,11 @@ def index():
     entries = load_entries()
     return render_template('index.html', entries=entries)
 
-
-@app.route('/upload', methods=['POST'])
+@app.route('/upload', methods=['GET', 'POST'])
 def upload():
+    if request.method == 'GET':
+        return render_template('upload.html')
+
     file = request.files.get('shot')
     title = request.form.get('title', '')
     movie = request.form.get('movie', '')

--- a/cine_storage/templates/index.html
+++ b/cine_storage/templates/index.html
@@ -23,33 +23,6 @@
         color: #FFB347;
       }
 
-      form {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 1em;
-        align-items: center;
-        margin-bottom: 2em;
-      }
-
-      form input[type="text"],
-      form input[type="file"] {
-        flex: 1;
-        padding: 0.5em;
-        background: #222;
-        border: 1px solid #777;
-        color: #eee;
-        border-radius: 4px;
-      }
-
-      form input[type="submit"] {
-        padding: 0.5em 1em;
-        background: #666;
-        color: #fff;
-        border: none;
-        border-radius: 4px;
-        cursor: pointer;
-      }
-
       .gallery {
         list-style: none;
         padding: 0;
@@ -71,21 +44,17 @@
         display: block;
         border-radius: 4px;
       }
+
+      a {
+        color: #FFB347;
+      }
     </style>
   </head>
   <body>
     <header>
       <h1>Cinematography Shots</h1>
     </header>
-    <form action="{{ url_for('upload') }}" method="post" enctype="multipart/form-data">
-      <input type="text" name="title" placeholder="Shot title" />
-      <input type="text" name="movie" placeholder="Movie" />
-      <input type="text" name="director" placeholder="Director" />
-      <input type="text" name="dop" placeholder="Director of Photography" />
-      <input type="number" name="year" placeholder="Year" min="1888" />
-      <input type="file" name="shot" required />
-      <input type="submit" value="Upload" />
-    </form>
+    <p><a href="{{ url_for('upload') }}">Upload a new shot</a></p>
 
     <ul class="gallery">
     {% for entry in entries %}

--- a/cine_storage/templates/upload.html
+++ b/cine_storage/templates/upload.html
@@ -1,0 +1,74 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Upload Shot</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style>
+      body {
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+        max-width: 900px;
+        margin: 0 auto;
+        padding: 2em;
+        background: #000;
+        color: #c0c0c0;
+      }
+
+      header {
+        text-align: center;
+        margin-bottom: 2em;
+      }
+
+      header h1 {
+        color: #FFB347;
+      }
+
+      form {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 1em;
+        align-items: center;
+        margin-bottom: 2em;
+      }
+
+      form input[type="text"],
+      form input[type="number"],
+      form input[type="file"] {
+        flex: 1;
+        padding: 0.5em;
+        background: #222;
+        border: 1px solid #777;
+        color: #eee;
+        border-radius: 4px;
+      }
+
+      form input[type="submit"] {
+        padding: 0.5em 1em;
+        background: #666;
+        color: #fff;
+        border: none;
+        border-radius: 4px;
+        cursor: pointer;
+      }
+
+      a {
+        color: #FFB347;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>Upload Shot</h1>
+    </header>
+    <form action="{{ url_for('upload') }}" method="post" enctype="multipart/form-data">
+      <input type="text" name="title" placeholder="Shot title" />
+      <input type="text" name="movie" placeholder="Movie" />
+      <input type="text" name="director" placeholder="Director" />
+      <input type="text" name="dop" placeholder="Director of Photography" />
+      <input type="number" name="year" placeholder="Year" min="1888" />
+      <input type="file" name="shot" required />
+      <input type="submit" value="Upload" />
+    </form>
+    <p><a href="{{ url_for('index') }}">Back to gallery</a></p>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- move upload form to a new `/upload` page
- keep gallery index simple with a link to the new upload UI
- document the new upload route in README

## Testing
- `pip install -r requirements.txt`
- `python cine_storage/app.py` *(fails: running server demonstrates flask runs)*

------
https://chatgpt.com/codex/tasks/task_e_6840bd56faa8833197387bb1cc693d84