### PR TITLE
Fix security warnings

### DIFF
--- a/cine_storage/app.py
+++ b/cine_storage/app.py
@@ -12,7 +12,7 @@ ALLOWED_EXTENSIONS = {'png', 'jpg', 'jpeg', 'gif'}
 app = Flask(__name__)
 app.config['UPLOAD_FOLDER'] = UPLOAD_FOLDER
 app.config['MAX_CONTENT_LENGTH'] = 16 * 1024 * 1024  # 16MB
-app.secret_key = 'dev'
+app.secret_key = os.environ.get('SECRET_KEY', os.urandom(24).hex())
 
 os.makedirs(UPLOAD_FOLDER, exist_ok=True)
 
@@ -72,4 +72,5 @@ def uploaded_file(filename):
 
 
 if __name__ == '__main__':
-    app.run(debug=True)
+    debug = os.environ.get('FLASK_DEBUG', '').lower() in {'1', 'true', 'yes'}
+    app.run(debug=debug)


### PR DESCRIPTION
## Summary
- improve Flask app security by reading secret key from environment
- allow disabling Flask debug mode with FLASK_DEBUG

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6840c11db1a48331a6165471cf5012c6