### PR TITLE
Add OAuth login

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 A simple Flask application for storing and displaying cinematography shots. Upload images with metadata including title, movie, director, director of photography, and release year. Browse your gallery with all details shown.
 
-Visit `/` to view the gallery. Use `/upload` to add new shots with their metadata.
+Authentication is handled via OAuth (GitHub or Google) using Flask-Login. You must be logged in to upload shots.
+
+Visit `/` to view the gallery. When logged in you can use `/upload` to add new shots with their metadata.
 
 ### Running locally
 
@@ -10,5 +12,13 @@ Visit `/` to view the gallery. Use `/upload` to add new shots with their metadat
 pip install -r requirements.txt
 python cine_storage/app.py
 ```
+
+Set the following environment variables with your OAuth credentials before running:
+
+- `GITHUB_CLIENT_ID` and `GITHUB_CLIENT_SECRET`
+- `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET`
+- `SECRET_KEY` (optional, for session security)
+
+With these set, start the app and log in via GitHub or Google to upload images.
 
 The uploads are stored in `cine_storage/uploads`. They are ignored by Git via `.gitignore`.

--- a/cine_storage/app.py
+++ b/cine_storage/app.py
@@ -2,6 +2,15 @@ import os
 import json
 from datetime import datetime
 from flask import Flask, render_template, request, redirect, url_for, send_from_directory
+from flask_login import (
+    LoginManager,
+    UserMixin,
+    login_user,
+    logout_user,
+    login_required,
+    current_user,
+)
+from authlib.integrations.flask_client import OAuth
 from werkzeug.utils import secure_filename
 
 BASE_DIR = os.path.dirname(__file__)
@@ -14,7 +23,46 @@ app.config['UPLOAD_FOLDER'] = UPLOAD_FOLDER
 app.config['MAX_CONTENT_LENGTH'] = 16 * 1024 * 1024  # 16MB
 app.secret_key = os.environ.get('SECRET_KEY', os.urandom(24).hex())
 
+# Flask-Login setup
+login_manager = LoginManager(app)
+login_manager.login_view = 'index'
+
+# OAuth setup
+oauth = OAuth(app)
+oauth.register(
+    name='github',
+    client_id=os.environ.get('GITHUB_CLIENT_ID'),
+    client_secret=os.environ.get('GITHUB_CLIENT_SECRET'),
+    access_token_url='https://github.com/login/oauth/access_token',
+    authorize_url='https://github.com/login/oauth/authorize',
+    api_base_url='https://api.github.com/',
+    client_kwargs={'scope': 'user:email'},
+)
+oauth.register(
+    name='google',
+    client_id=os.environ.get('GOOGLE_CLIENT_ID'),
+    client_secret=os.environ.get('GOOGLE_CLIENT_SECRET'),
+    access_token_url='https://oauth2.googleapis.com/token',
+    authorize_url='https://accounts.google.com/o/oauth2/auth',
+    api_base_url='https://www.googleapis.com/oauth2/v1/',
+    client_kwargs={'scope': 'openid email profile'},
+)
+
 os.makedirs(UPLOAD_FOLDER, exist_ok=True)
+
+
+class User(UserMixin):
+    def __init__(self, user_id: str, name: str):
+        self.id = user_id
+        self.name = name
+
+
+users = {}
+
+
+@login_manager.user_loader
+def load_user(user_id: str):
+    return users.get(user_id)
 
 
 def allowed_file(filename: str) -> bool:
@@ -33,12 +81,47 @@ def save_entries(entries) -> None:
         json.dump(entries, f)
 
 
+@app.route('/login/<provider>')
+def oauth_login(provider: str):
+    client = oauth.create_client(provider)
+    redirect_uri = url_for('authorize', provider=provider, _external=True)
+    return client.authorize_redirect(redirect_uri)
+
+
+@app.route('/authorize/<provider>')
+def authorize(provider: str):
+    client = oauth.create_client(provider)
+    token = client.authorize_access_token()
+    if provider == 'github':
+        resp = client.get('user', token=token)
+        info = resp.json()
+        uid = str(info['id'])
+        name = info.get('name') or info.get('login')
+    else:
+        resp = client.get('userinfo', token=token)
+        info = resp.json()
+        uid = info['id']
+        name = info.get('name')
+    user = User(uid, name)
+    users[uid] = user
+    login_user(user)
+    return redirect(url_for('index'))
+
+
+@app.route('/logout')
+@login_required
+def logout():
+    logout_user()
+    return redirect(url_for('index'))
+
+
 @app.route('/')
 def index():
     entries = load_entries()
     return render_template('index.html', entries=entries)
 
 @app.route('/upload', methods=['GET', 'POST'])
+@login_required
 def upload():
     if request.method == 'GET':
         return render_template('upload.html')

--- a/cine_storage/templates/index.html
+++ b/cine_storage/templates/index.html
@@ -63,8 +63,20 @@
   <body>
     <header>
       <h1>PURE CINEMA</h1>
+      <p>
+        {% if current_user.is_authenticated %}
+          Logged in as {{ current_user.name }} |
+          <a href="{{ url_for('logout') }}">Logout</a>
+        {% else %}
+          <a href="{{ url_for('oauth_login', provider='github') }}">Login with GitHub</a>
+          |
+          <a href="{{ url_for('oauth_login', provider='google') }}">Login with Google</a>
+        {% endif %}
+      </p>
     </header>
+    {% if current_user.is_authenticated %}
     <p><a href="{{ url_for('upload') }}">Upload a new shot</a></p>
+    {% endif %}
 
     <ul class="gallery">
     {% for entry in entries %}

--- a/cine_storage/templates/upload.html
+++ b/cine_storage/templates/upload.html
@@ -59,6 +59,16 @@
   <body>
     <header>
       <h1>Upload Shot</h1>
+      <p>
+        {% if current_user.is_authenticated %}
+          Logged in as {{ current_user.name }} |
+          <a href="{{ url_for('logout') }}">Logout</a>
+        {% else %}
+          <a href="{{ url_for('oauth_login', provider='github') }}">Login with GitHub</a>
+          |
+          <a href="{{ url_for('oauth_login', provider='google') }}">Login with Google</a>
+        {% endif %}
+      </p>
     </header>
     <form action="{{ url_for('upload') }}" method="post" enctype="multipart/form-data">
       <input type="text" name="title" placeholder="Shot title" />

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 Flask
+Flask-Login
+Authlib


### PR DESCRIPTION
## Summary
- add OAuth login via GitHub and Google using Flask-Login
- display login/logout status in templates
- require login for uploading
- document OAuth setup in README
- update dependencies

## Testing
- `python -m py_compile cine_storage/app.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_6840cb6b175c833180679f3dbbe3c293