### PR TITLE
Improve template accessibility and move CSS

### DIFF
--- a/cine_storage/static/style.css
+++ b/cine_storage/static/style.css
@@ -1,0 +1,121 @@
+:root {
+  --background-color: #000;
+  --text-color: #ddd;
+  --card-background: #111;
+  --input-background: #222;
+  --border-color: #555;
+  --accent-color: #FFB347;
+  --base-padding: 2em;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  max-width: 900px;
+  margin: 0 auto;
+  padding: var(--base-padding);
+  background: var(--background-color);
+  color: var(--text-color);
+}
+
+header {
+  text-align: center;
+  margin-bottom: 2em;
+}
+
+form.search {
+  margin: 1em 0;
+}
+
+form.search input[type="text"] {
+  width: 70%;
+  padding: 0.5em;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  background: var(--input-background);
+  color: #eee;
+}
+
+.gallery {
+  list-style: none;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+  gap: 2em;
+}
+
+.gallery li {
+  background: var(--card-background);
+  padding: 1em;
+  border-radius: 8px;
+}
+
+.gallery img {
+  width: 100%;
+  height: auto;
+  display: block;
+  border-radius: 4px;
+}
+
+dl {
+  margin-top: 0.5em;
+}
+
+dt {
+  font-weight: bold;
+}
+
+dd {
+  margin: 0 0 0.5em 0;
+}
+
+a {
+  color: var(--accent-color);
+}
+
+form {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1em;
+  align-items: center;
+  margin-bottom: 2em;
+}
+
+form input[type="text"],
+form input[type="number"],
+form input[type="file"] {
+  flex: 1;
+  padding: 0.5em;
+  background: var(--input-background);
+  border: 1px solid #777;
+  color: #eee;
+  border-radius: 4px;
+}
+
+form input[type="submit"] {
+  padding: 0.5em 1em;
+  background: #666;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+@media (max-width: 600px) {
+  body { padding: 1em; }
+  form input[type="text"],
+  form input[type="number"],
+  form input[type="file"] {
+    flex-basis: 100%;
+  }
+}

--- a/cine_storage/templates/index.html
+++ b/cine_storage/templates/index.html
@@ -4,54 +4,7 @@
     <meta charset="utf-8">
     <title>PURE CINEMA</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <style>
-      body {
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
-        max-width: 900px;
-        margin: 0 auto;
-        padding: 2em;
-        background: #000;
-        color: #ddd;
-      }
-      header {
-        text-align: center;
-        margin-bottom: 2em;
-      }
-      form.search {
-        margin-top: 1em;
-        margin-bottom: 1em;
-      }
-      form.search input[type="text"] {
-        width: 70%;
-        padding: 0.5em;
-        border: 1px solid #555;
-        border-radius: 4px;
-        background: #222;
-        color: #eee;
-      }
-      .gallery {
-        list-style: none;
-        padding: 0;
-        display: grid;
-        grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
-        gap: 2em;
-      }
-      .gallery li {
-        background: #111;
-        padding: 1em;
-        border-radius: 8px;
-      }
-      .gallery img {
-        width: 100%;
-        height: auto;
-        display: block;
-        border-radius: 4px;
-      }
-      a { color: #FFB347; }
-      @media (max-width: 600px) {
-        body { padding: 1em; }
-      }
-    </style>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
   </head>
   <body>
     <header>
@@ -66,7 +19,8 @@
         {% endif %}
       </p>
       <form class="search" action="{{ url_for('index') }}" method="get">
-        <input type="text" name="q" value="{{ query or '' }}" placeholder="Search shots...">
+        <label for="search-input" class="visually-hidden">Search shots</label>
+        <input id="search-input" type="text" name="q" value="{{ query or '' }}" placeholder="Search shots...">
       </form>
     </header>
     {% if current_user.is_authenticated %}
@@ -77,14 +31,26 @@
       <li>
         {% if entry.title %}<h3>{{ entry.title }}</h3>{% endif %}
         <a href="{{ url_for('uploaded_file', filename=entry.filename) }}">
-          <img src="{{ url_for('thumbnail', filename=entry.filename) }}" alt="{{ entry.title }}" />
+          <img src="{{ url_for('thumbnail', filename=entry.filename) }}" alt="Cinematic shot from {{ entry.movie or 'an unknown film' }}.{% if entry.title %} Titled: {{ entry.title }}{% endif %}" />
         </a>
-        <p>
-          {% if entry.movie %}<strong>Movie:</strong> {{ entry.movie }}<br>{% endif %}
-          {% if entry.director %}<strong>Director:</strong> {{ entry.director }}<br>{% endif %}
-          {% if entry.dop %}<strong>DOP:</strong> {{ entry.dop }}<br>{% endif %}
-          {% if entry.year %}<strong>Year:</strong> {{ entry.year }}{% endif %}
-        </p>
+        <dl>
+          {% if entry.movie %}
+            <dt>Movie</dt>
+            <dd>{{ entry.movie }}</dd>
+          {% endif %}
+          {% if entry.director %}
+            <dt>Director</dt>
+            <dd>{{ entry.director }}</dd>
+          {% endif %}
+          {% if entry.dop %}
+            <dt>DOP</dt>
+            <dd>{{ entry.dop }}</dd>
+          {% endif %}
+          {% if entry.year %}
+            <dt>Year</dt>
+            <dd>{{ entry.year }}</dd>
+          {% endif %}
+        </dl>
       </li>
     {% else %}
       <li>No shots yet.</li>

--- a/cine_storage/templates/upload.html
+++ b/cine_storage/templates/upload.html
@@ -4,58 +4,7 @@
     <meta charset="utf-8">
     <title>Upload Shot</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <style>
-      body {
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
-        max-width: 900px;
-        margin: 0 auto;
-        padding: 2em;
-        background: #000;
-        color: #c0c0c0;
-      }
-      header {
-        text-align: center;
-        margin-bottom: 2em;
-      }
-      header h1 {
-        color: #FFB347;
-        margin: 0;
-      }
-      form {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 1em;
-        align-items: center;
-        margin-bottom: 2em;
-      }
-      form input[type="text"],
-      form input[type="number"],
-      form input[type="file"] {
-        flex: 1;
-        padding: 0.5em;
-        background: #222;
-        border: 1px solid #777;
-        color: #eee;
-        border-radius: 4px;
-      }
-      form input[type="submit"] {
-        padding: 0.5em 1em;
-        background: #666;
-        color: #fff;
-        border: none;
-        border-radius: 4px;
-        cursor: pointer;
-      }
-      a { color: #FFB347; }
-      @media (max-width: 600px) {
-        body { padding: 1em; }
-        form input[type="text"],
-        form input[type="number"],
-        form input[type="file"] {
-          flex-basis: 100%;
-        }
-      }
-    </style>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
   </head>
   <body>
     <header>


### PR DESCRIPTION
## Summary
- move inline CSS to a shared `static/style.css`
- modernize CSS with variables and extra helpers
- link the new stylesheet from templates
- add an accessible label for search
- convert metadata to `<dl>` and expand image alt text

## Testing
- `python -m py_compile cine_storage/*.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68473762944083318235b9e8470b5c56